### PR TITLE
Update for Laravel 6.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "~5.0"
+        "illuminate/support": "~5.0 || ~6.0"
     },
     "autoload": {
         "psr-0": {

--- a/src/Codecourse/Notify/Notifier.php
+++ b/src/Codecourse/Notify/Notifier.php
@@ -100,6 +100,10 @@ class Notifier
      */
     public function option($key, $default = null)
     {
+        if(class_exists('\Arr')) {
+            return \Arr::get($this->options(true), $key, $default);
+        }
+    
         return array_get($this->options(true), $key, $default);
     }
 }


### PR DESCRIPTION
Added 6.0 branch for illuminate/support to composer requirements.

Updated option function in Notifier.php to use Arr::get() if the '\Arr' class is available, if not it uses array_get().